### PR TITLE
Adding RC Channels control to configurator.

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "minimum_chrome_version": "38",
-    "version": "0.10.0",
+    "version": "0.11.0",
     "author": "TobiasBales",
     "name": "PlayUAV OSD Configurator",
     "short_name": "playuavosdconfigurator",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playuav-osd-configurator",
   "productName": "PlayUAVOSDConfigurator",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A simple cross platform tool to configure the PlayUAV OSD",
   "main": "main.js",
   "bugs": {

--- a/src/config/ParametersModule.js
+++ b/src/config/ParametersModule.js
@@ -185,6 +185,10 @@ class ParametersModule extends Component {
             parameters={this._props('linkQuality')}
             {...this._actions()}
           />
+          <Settings.RCChannels
+            parameters={this._props('rcChannels')}
+            {...this._actions()}
+          />
           <Settings.WPDistance
             parameters={this._props('wpDistance')}
             {...this._actions()}

--- a/src/config/settings/RCChannels.js
+++ b/src/config/settings/RCChannels.js
@@ -1,0 +1,63 @@
+import React, { Component, PropTypes } from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import Parameters from '../parameters';
+import Column from '../../components/Column';
+import CustomPropTypes from '../../utils/PropTypes';
+
+// Cribbed from Throttle.js originally
+export default class RCChannels extends Component {
+  static propTypes = {
+    parameters: ImmutablePropTypes.contains({
+      numberOfPanels: PropTypes.number.isRequired,
+      positionX: CustomPropTypes.value(PropTypes.number.isRequired).isRequired,
+      positionY: CustomPropTypes.value(PropTypes.number.isRequired).isRequired,
+      //scaleEnabled: CustomPropTypes.value(PropTypes.number.isRequired).isRequired,
+      //scaleType: CustomPropTypes.value(PropTypes.number.isRequired).isRequired,
+      visibleOn: CustomPropTypes.value(PropTypes.number.isRequired).isRequired,
+    }).isRequired,
+    setPosition: PropTypes.func.isRequired,
+    //setScaleEnabled: PropTypes.func.isRequired,
+    //setScaleType: PropTypes.func.isRequired,
+    setVisibleOn: PropTypes.func.isRequired,
+  }
+
+  shouldComponentUpdate(nextProps) {
+    return !this.props.parameters.equals(nextProps.parameters);
+  }
+
+ /*
+  _setScaleEnabled = (enabled) => {
+    this.props.setScaleEnabled('throttle', enabled);
+  }
+
+  _setScaleType = (type) => {
+    this.props.setScaleType('throttle', type);
+  }
+*/  
+
+  render() {
+    //alert('hello');
+    const { setPosition, setVisibleOn } = this.props;
+    const {
+      numberOfPanels, positionX, positionY, visibleOn
+    } = this.props.parameters;
+    /*
+    const scaleEnabledOptions = [
+      { value: 0, label: 'number' }, { value: 1, label: 'scale' },
+    ];
+    const scaleTypeOptions = [
+      { value: 0, label: 'vertical' }, { value: 1, label: 'horizontal' }
+    ];
+    */
+    return (
+      <Parameters.ParameterList name="rc channels">
+        <Parameters.Position labelX="position x" labelY="position y" name="rcChannels"
+          positionX={positionX} positionY={positionY} setPosition={setPosition}
+        />
+        <Parameters.VisibleOn visibleOn={visibleOn} name="rcChannels"
+          setVisibleOn={setVisibleOn} numberOfPanels={numberOfPanels}
+        />
+      </Parameters.ParameterList>
+    );
+  }
+}

--- a/src/config/settings/RCChannels.js
+++ b/src/config/settings/RCChannels.js
@@ -4,20 +4,15 @@ import Parameters from '../parameters';
 import Column from '../../components/Column';
 import CustomPropTypes from '../../utils/PropTypes';
 
-// Cribbed from Throttle.js originally
 export default class RCChannels extends Component {
   static propTypes = {
     parameters: ImmutablePropTypes.contains({
       numberOfPanels: PropTypes.number.isRequired,
       positionX: CustomPropTypes.value(PropTypes.number.isRequired).isRequired,
       positionY: CustomPropTypes.value(PropTypes.number.isRequired).isRequired,
-      //scaleEnabled: CustomPropTypes.value(PropTypes.number.isRequired).isRequired,
-      //scaleType: CustomPropTypes.value(PropTypes.number.isRequired).isRequired,
       visibleOn: CustomPropTypes.value(PropTypes.number.isRequired).isRequired,
     }).isRequired,
     setPosition: PropTypes.func.isRequired,
-    //setScaleEnabled: PropTypes.func.isRequired,
-    //setScaleType: PropTypes.func.isRequired,
     setVisibleOn: PropTypes.func.isRequired,
   }
 
@@ -25,30 +20,11 @@ export default class RCChannels extends Component {
     return !this.props.parameters.equals(nextProps.parameters);
   }
 
- /*
-  _setScaleEnabled = (enabled) => {
-    this.props.setScaleEnabled('throttle', enabled);
-  }
-
-  _setScaleType = (type) => {
-    this.props.setScaleType('throttle', type);
-  }
-*/  
-
   render() {
-    //alert('hello');
     const { setPosition, setVisibleOn } = this.props;
     const {
       numberOfPanels, positionX, positionY, visibleOn
     } = this.props.parameters;
-    /*
-    const scaleEnabledOptions = [
-      { value: 0, label: 'number' }, { value: 1, label: 'scale' },
-    ];
-    const scaleTypeOptions = [
-      { value: 0, label: 'vertical' }, { value: 1, label: 'horizontal' }
-    ];
-    */
     return (
       <Parameters.ParameterList name="rc channels">
         <Parameters.Position labelX="position x" labelY="position y" name="rcChannels"

--- a/src/config/settings/index.js
+++ b/src/config/settings/index.js
@@ -25,6 +25,7 @@ import GpsStatus from './GpsStatus';
 import HomeDirection from './HomeDirection';
 import HomeDistance from './HomeDistance';
 import LinkQuality from './LinkQuality';
+import RCChannels from './RCChannels';
 import Map from './Map';
 import Radar from './Radar';
 import RelativeAltitude from './RelativeAltitude';
@@ -71,6 +72,7 @@ export default {
   HomeDirection,
   HomeDistance,
   LinkQuality,
+  RCChannels,
   Map,
   Radar,
   RelativeAltitude,

--- a/src/preview/Preview.js
+++ b/src/preview/Preview.js
@@ -18,7 +18,7 @@ function Preview(props) {
   const {
     absoluteAltitude, alarms, altitudeScale, armState, artificialHorizont, batteryConsumed,
     batteryCurrent, batteryRemaining, batteryVoltage, climbRate, compass, efficiency,
-    flightMode, linkQuality, homeLatitude, homeLongitude, gpsHdop, gpsLatitude, gpsLongitude,
+    flightMode, linkQuality, rcChannels, homeLatitude, homeLongitude, gpsHdop, gpsLatitude, gpsLongitude,
     gpsStatus, gps2Hdop, gps2Latitude, gps2Longitude, gps2Status, homeDirection, homeDistance,
     radar, relativeAltitude, rssi, speedAir, speedScale, speedGround, throttle, time,
     totalTrip, varioGraph, watt, wpDistance, wind,
@@ -164,6 +164,9 @@ function Preview(props) {
           />
           <Previews.HomeDistance {...homeDistance.toJS()} {...fcStatus}
             units={units} setPosition={setPosition('homeDistance')}
+          />
+          <Previews.RCChannels {...rcChannels.toJS()} {...fcStatus}
+            setPosition={setPosition('rcChannels')}
           />
           <Previews.LinkQuality {...linkQuality.toJS()} {...fcStatus}
             setPosition={setPosition('linkQuality')}

--- a/src/preview/RCChannels.js
+++ b/src/preview/RCChannels.js
@@ -4,9 +4,6 @@ import Canvas from '../utils/Canvas';
 import PreviewBase from './PreviewBase';
 import fonts from '../utils/fonts';
 
-
-// This is just the throttle preview at the moment! Needs to be
-// customized for the RC Channels control
 export default class RCChannelsPreview extends PreviewBase {
   static propTypes = {
     panel: PropTypes.number.isRequired,

--- a/src/preview/RCChannels.js
+++ b/src/preview/RCChannels.js
@@ -1,0 +1,86 @@
+import React, { PropTypes } from 'react';
+import * as Canvas_types from '../utils/Canvas';
+import Canvas from '../utils/Canvas';
+import PreviewBase from './PreviewBase';
+import fonts from '../utils/fonts';
+
+
+// This is just the throttle preview at the moment! Needs to be
+// customized for the RC Channels control
+export default class RCChannelsPreview extends PreviewBase {
+  static propTypes = {
+    panel: PropTypes.number.isRequired,
+    positionX: PropTypes.number.isRequired,
+    positionY: PropTypes.number.isRequired,
+    visibleOn: PropTypes.number.isRequired,
+  }
+
+  draw() {
+    const font = fonts.getFont(0);
+    this.canvas.clear();
+      
+    if ((this.props.visibleOn & Math.pow(2, this.props.panel)) !== 0) {
+        var default_channel_count = 8;
+        
+        // Just some sample channel values, possibly not realistic
+        var channelValues = [ 1524, 1520, 1750, 1250, 1400, 1800, 1950, 1515];               
+        
+        var bar_x_offset = 85;
+        var currentLineYOffset = 0;
+        // TODO: Could make bar width configurable in firmware, but we'll see if anyone cares first
+        var bar_width = 40;
+        for (let chanNumber = 1; chanNumber <= default_channel_count; chanNumber++) {
+            var currentChannelPwmValue = channelValues[chanNumber-1];
+            // Draw the channel label and numeric value ('CH 2  1250')
+            var curChanString = 'CH ' + chanNumber + ' ' + currentChannelPwmValue + ' ';            
+            var chanStringPosition = Canvas.calculateStringPosition(curChanString, 0, currentLineYOffset, Canvas_types.H_ALIGNMENT_LEFT, Canvas_types.V_ALIGNMENT_TOP, font);
+            this.canvas.drawString(curChanString, 0, currentLineYOffset, font);            
+            
+            // Draw the bar to the side of the text that represents the current numeric value
+            var barXPos = bar_x_offset;
+            var barYPos = currentLineYOffset;
+            var barHeight = chanStringPosition.height;
+            var isBlack = false;
+            var isOutline = true;            
+            this.canvas.drawRectangle(barXPos, barYPos, bar_width, chanStringPosition.height, isBlack, isOutline);
+            
+            // Normalize 1000-2000 PPM value to 0-1000
+            var normalized_channel_value = currentChannelPwmValue - 1000;
+            if (normalized_channel_value < 0) {
+                normalized_channel_value = 0;
+            } else if (normalized_channel_value > 1000) {
+                normalized_channel_value = 1000;
+            }
+            
+            // X offset position for the stripe relative to the bar
+            var stripe_offset_x = (normalized_channel_value * bar_width) / 1000;    
+
+            // Draw vertical stripe marking channel value on bar rectangle
+            var stripeXPos = barXPos + stripe_offset_x;            
+            this.canvas.drawLine(stripeXPos - 1, barYPos, stripeXPos - 1, barYPos + chanStringPosition.height, false, true);
+            this.canvas.drawLine(stripeXPos, barYPos, stripeXPos, barYPos + chanStringPosition.height, false, true);
+            this.canvas.drawLine(stripeXPos + 1, barYPos, stripeXPos + 1, barYPos + chanStringPosition.height, false, true);
+            
+            // Move Y position down one line
+            currentLineYOffset += chanStringPosition.height;           
+        }
+    }
+  }
+
+  render() {
+    const { positionX, positionY } = this.props;
+    const visible = (this.props.visibleOn & Math.pow(2, this.props.panel)) !== 0;
+
+    return (
+      !visible ?
+        <canvas ref="canvas" /> :
+        <canvas
+          ref="canvas"
+          style={{ left: positionX, top: positionY }}
+          width={300}
+          height={300}
+          className="preview-widget"
+        />
+    );
+  }
+}

--- a/src/preview/index.js
+++ b/src/preview/index.js
@@ -20,6 +20,7 @@ import GpsStatus from './GpsStatus';
 import HomeDirection from './HomeDirection';
 import HomeDistance from './HomeDistance';
 import LinkQuality from './LinkQuality';
+import RCChannels from './RCChannels';
 import Radar from './Radar';
 import RelativeAltitude from './RelativeAltitude';
 import Rssi from './Rssi';
@@ -57,6 +58,7 @@ export default {
   HomeDirection,
   HomeDistance,
   LinkQuality,
+  RCChannels,
   Radar,
   RelativeAltitude,
   Rssi,

--- a/src/utils/eeprom.js
+++ b/src/utils/eeprom.js
@@ -19,7 +19,9 @@ const defaultEEPROM = [
   0, 0, 0, 1, 7, 1, 1, 1, 350, 200, 0, 2, 1, 1,
   0, 0, 200, 220, 0, 0, 5, 1000, 2000, 0, 0, 0, 200, 200,
   1, 1, 15, 15, 1, 1, 184, 240, 0, 0, 1, 1, 264, 240, 0, 0, 0, 0, 0, 0, 0, 0,
-  5000, 1000
+  5000, 1000,
+  // New parameters for rc channels.
+  0, 0, 55, 40
 ];
 
 function toEnabled(byte) {
@@ -379,9 +381,15 @@ const eepromMapping = [
   { path: ['watt', 'positionY'] },
   { path: ['watt', 'fontSize'] },
   { path: ['watt', 'hAlignment'] },
-  
   { path: ['serial', 'splashMillisecondsToShowValue'] },  
-  { path: ['alarms', 'alarmMillisecondsToShowValue'] }
+  { path: ['alarms', 'alarmMillisecondsToShowValue'] },
+  
+  { path: ['rcChannels', 'visibleOn'],
+    convertFromParameters: toEnabled },
+  { path: ['rcChannels', 'visibleOn'] },
+  { path: ['rcChannels', 'positionX'] },
+  { path: ['rcChannels', 'positionY'] }
+  
   
 ];
 
@@ -414,6 +422,7 @@ const skeletonParameters = {
   homeDirection: {},
   homeDistance: {},
   linkQuality: {},
+  rcChannels: {},
   map: {},
   preview: {},
   pwmPanel: {},


### PR DESCRIPTION
This adds configuration to the Configurator for the RC Channels display:

![configuratorchannelpreview](https://cloud.githubusercontent.com/assets/7128339/20090799/35c489e6-a544-11e6-9d7c-23685a98ff0c.png)

See also https://github.com/TobiasBales/PlayuavOSD/pull/33