### PR TITLE
Home direction panel control for submit

### DIFF
--- a/src/config/ParametersModule.js
+++ b/src/config/ParametersModule.js
@@ -105,6 +105,10 @@ class ParametersModule extends Component {
             parameters={this._props('homeDirection')}
             {...this._actions()}
           />
+          <Settings.HomeDirectionDebugInfo
+            parameters={this._props('homeDirectionDebugInfo')}
+            {...this._actions()}
+          />
           <Settings.Radar
             parameters={this._props('radar')}
             {...this._actions()}

--- a/src/config/settings/HomeDirectionDebugInfo.js
+++ b/src/config/settings/HomeDirectionDebugInfo.js
@@ -1,0 +1,45 @@
+import React, { Component, PropTypes } from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import Parameters from '../parameters';
+import CustomPropTypes from '../../utils/PropTypes';
+
+export default class HomeDirectionDebugInfo extends Component {
+  static propTypes = {
+    parameters: ImmutablePropTypes.contains({
+      numberOfPanels: PropTypes.number.isRequired,
+      positionX: CustomPropTypes.value(PropTypes.number.isRequired).isRequired,
+      positionY: CustomPropTypes.value(PropTypes.number.isRequired).isRequired,
+      visibleOn: CustomPropTypes.value(PropTypes.number.isRequired).isRequired,
+    }).isRequired,
+    setPosition: PropTypes.func.isRequired,
+    setVisibleOn: PropTypes.func.isRequired,
+  }
+
+  shouldComponentUpdate(nextProps) {
+    return !this.props.parameters.equals(nextProps.parameters);
+  }
+
+  render() {
+    const {
+      setPosition,
+      setVisibleOn,
+    } = this.props;
+    const {
+      numberOfPanels,
+      positionX,
+      positionY,
+      visibleOn,
+    } = this.props.parameters;
+
+    return (
+      <Parameters.ParameterList name="home direction debug info">
+        <Parameters.Position labelX="position x" labelY="position y" name="homeDirectionDebugInfo"
+          positionX={positionX} positionY={positionY} setPosition={setPosition}
+        />
+        <Parameters.VisibleOn visibleOn={visibleOn} name="homeDirectionDebugInfo"
+          setVisibleOn={setVisibleOn} numberOfPanels={numberOfPanels}
+        />
+      </Parameters.ParameterList>
+    );
+  }
+}

--- a/src/config/settings/index.js
+++ b/src/config/settings/index.js
@@ -23,6 +23,7 @@ import GpsLatitude from './GpsLatitude';
 import GpsLongitude from './GpsLongitude';
 import GpsStatus from './GpsStatus';
 import HomeDirection from './HomeDirection';
+import HomeDirectionDebugInfo from './HomeDirectionDebugInfo';
 import HomeDistance from './HomeDistance';
 import LinkQuality from './LinkQuality';
 import RCChannels from './RCChannels';
@@ -70,6 +71,7 @@ export default {
   GpsLongitude,
   GpsStatus,
   HomeDirection,
+  HomeDirectionDebugInfo,
   HomeDistance,
   LinkQuality,
   RCChannels,

--- a/src/preview/HomeDirectionDebugInfo.js
+++ b/src/preview/HomeDirectionDebugInfo.js
@@ -1,0 +1,57 @@
+import React, { PropTypes } from 'react';
+import * as Canvas_types from '../utils/Canvas';
+import Canvas from '../utils/Canvas';
+import PreviewBase from './PreviewBase';
+import fonts from '../utils/fonts';
+
+export default class HomeDirectionDebugInfo extends PreviewBase {
+  static propTypes = {
+    panel: PropTypes.number.isRequired,
+    positionX: PropTypes.number.isRequired,
+    positionY: PropTypes.number.isRequired,
+    visibleOn: PropTypes.number.isRequired,
+  }
+
+  draw() {
+    const font = fonts.getFont(0);      
+    this.canvas.clear();
+    const height = this.refs.canvas.height;
+
+    if ((this.props.visibleOn & Math.pow(2, this.props.panel)) !== 0) {
+        var debugLines = [ 
+                            'abs h.b. 68',
+                            'rel h.b. -7',
+                            'comp. b 75'
+                         ];    
+        var currentLineYOffset = 0;                         
+        for (let debugLineIndex = 0; debugLineIndex < debugLines.length; debugLineIndex++) {
+            // Get the current line
+            var currentDebugLine = debugLines[debugLineIndex];                                        
+            // Draw the current line
+            var debugLineStringPosition = Canvas.calculateStringPosition(currentDebugLine, 0, currentLineYOffset, Canvas_types.H_ALIGNMENT_LEFT, Canvas_types.V_ALIGNMENT_TOP, font);
+            this.canvas.drawString(currentDebugLine, 0, currentLineYOffset, font); 
+            // Move Y position down one line
+            currentLineYOffset += debugLineStringPosition.height;    
+        }
+    }
+  }
+
+  render() {
+    const { positionX, positionY } = this.props;
+    const height = 90;
+    const width = 300;
+    const visible = (this.props.visibleOn & Math.pow(2, this.props.panel)) !== 0;
+
+    return (
+      !visible ?
+        <canvas ref="canvas" /> :
+        <canvas
+          ref="canvas"
+          style={{ left: positionX, top: positionY }}
+          width={height}
+          height={width}
+          className="preview-widget"
+        />
+    );
+  }
+}

--- a/src/preview/HomeDirectionDebugInfo.js
+++ b/src/preview/HomeDirectionDebugInfo.js
@@ -13,7 +13,7 @@ export default class HomeDirectionDebugInfo extends PreviewBase {
   }
 
   draw() {
-    const font = fonts.getFont(0);      
+    const font = fonts.getFont(0);
     this.canvas.clear();
     const height = this.refs.canvas.height;
 
@@ -23,15 +23,15 @@ export default class HomeDirectionDebugInfo extends PreviewBase {
                             'rel h.b. -7',
                             'comp. b 75'
                          ];    
-        var currentLineYOffset = 0;                         
+        var currentLineYOffset = 0;
         for (let debugLineIndex = 0; debugLineIndex < debugLines.length; debugLineIndex++) {
             // Get the current line
-            var currentDebugLine = debugLines[debugLineIndex];                                        
+            var currentDebugLine = debugLines[debugLineIndex];
             // Draw the current line
             var debugLineStringPosition = Canvas.calculateStringPosition(currentDebugLine, 0, currentLineYOffset, Canvas_types.H_ALIGNMENT_LEFT, Canvas_types.V_ALIGNMENT_TOP, font);
             this.canvas.drawString(currentDebugLine, 0, currentLineYOffset, font); 
             // Move Y position down one line
-            currentLineYOffset += debugLineStringPosition.height;    
+            currentLineYOffset += debugLineStringPosition.height;
         }
     }
   }

--- a/src/preview/Preview.js
+++ b/src/preview/Preview.js
@@ -19,7 +19,7 @@ function Preview(props) {
     absoluteAltitude, alarms, altitudeScale, armState, artificialHorizont, batteryConsumed,
     batteryCurrent, batteryRemaining, batteryVoltage, climbRate, compass, efficiency,
     flightMode, linkQuality, rcChannels, homeLatitude, homeLongitude, gpsHdop, gpsLatitude, gpsLongitude,
-    gpsStatus, gps2Hdop, gps2Latitude, gps2Longitude, gps2Status, homeDirection, homeDistance,
+    gpsStatus, gps2Hdop, gps2Latitude, gps2Longitude, gps2Status, homeDirection, homeDirectionDebugInfo, homeDistance,
     radar, relativeAltitude, rssi, speedAir, speedScale, speedGround, throttle, time,
     totalTrip, varioGraph, watt, wpDistance, wind,
   } = props.parameters;
@@ -162,6 +162,11 @@ function Preview(props) {
           <Previews.HomeDirection {...homeDirection.toJS()} {...fcStatus}
             setPosition={setPosition('homeDirection')}
           />
+          
+          <Previews.HomeDirectionDebugInfo {...homeDirectionDebugInfo.toJS()} {...fcStatus}
+            setPosition={setPosition('homeDirectionDebugInfo')}
+          />
+          
           <Previews.HomeDistance {...homeDistance.toJS()} {...fcStatus}
             units={units} setPosition={setPosition('homeDistance')}
           />

--- a/src/preview/index.js
+++ b/src/preview/index.js
@@ -18,6 +18,7 @@ import GpsLatitude from './GpsLatitude';
 import GpsLongitude from './GpsLongitude';
 import GpsStatus from './GpsStatus';
 import HomeDirection from './HomeDirection';
+import HomeDirectionDebugInfo from './HomeDirectionDebugInfo';
 import HomeDistance from './HomeDistance';
 import LinkQuality from './LinkQuality';
 import RCChannels from './RCChannels';
@@ -56,6 +57,7 @@ export default {
   GpsLongitude,
   GpsStatus,
   HomeDirection,
+  HomeDirectionDebugInfo,
   HomeDistance,
   LinkQuality,
   RCChannels,

--- a/src/utils/eeprom.js
+++ b/src/utils/eeprom.js
@@ -21,7 +21,9 @@ const defaultEEPROM = [
   1, 1, 15, 15, 1, 1, 184, 240, 0, 0, 1, 1, 264, 240, 0, 0, 0, 0, 0, 0, 0, 0,
   5000, 1000,
   // New parameters for rc channels.
-  0, 0, 55, 40
+  0, 0, 55, 40,
+  // Parameters for home direction debug info panelChannel
+  0, 0, 65, 70
 ];
 
 function toEnabled(byte) {
@@ -381,15 +383,19 @@ const eepromMapping = [
   { path: ['watt', 'positionY'] },
   { path: ['watt', 'fontSize'] },
   { path: ['watt', 'hAlignment'] },
-  { path: ['serial', 'splashMillisecondsToShowValue'] },  
+  { path: ['serial', 'splashMillisecondsToShowValue'] },
   { path: ['alarms', 'alarmMillisecondsToShowValue'] },
-  
   { path: ['rcChannels', 'visibleOn'],
     convertFromParameters: toEnabled },
   { path: ['rcChannels', 'visibleOn'] },
   { path: ['rcChannels', 'positionX'] },
-  { path: ['rcChannels', 'positionY'] }
-  
+  { path: ['rcChannels', 'positionY'] },
+    
+  { path: ['homeDirectionDebugInfo', 'visibleOn'],
+    convertFromParameters: toEnabled },
+  { path: ['homeDirectionDebugInfo', 'visibleOn'] },
+  { path: ['homeDirectionDebugInfo', 'positionX'] },
+  { path: ['homeDirectionDebugInfo', 'positionY'] },
   
 ];
 
@@ -420,6 +426,7 @@ const skeletonParameters = {
   gpsLongitude: {},
   gpsStatus: {},
   homeDirection: {},
+  homeDirectionDebugInfo: {},
   homeDistance: {},
   linkQuality: {},
   rcChannels: {},


### PR DESCRIPTION
This allows user to turn the home arrow debug text on or off, and to position it independently of the home arrow itself.

![homedirectiondebugconfiguratorscreenshot](https://cloud.githubusercontent.com/assets/7128339/20180739/8e93c320-a710-11e6-862e-9958003a9079.png)

See also https://github.com/TobiasBales/PlayuavOSD/pull/34