### PR TITLE
Fixing imperial units to preview correctly for scale controls

### DIFF
--- a/src/preview/AltitudeScale.js
+++ b/src/preview/AltitudeScale.js
@@ -28,7 +28,7 @@ export default class AltitudeScale extends PreviewBase {
       const prefixPosition = Canvas.calculateStringPosition(prefix, 0, 0, hAlignment, 0, font);
       var unitString = ''
       if (this.props.units === 0) {
-        unitString = 'KM';
+        unitString = 'M';
       } else {
         unitString = 'F';
       }

--- a/src/preview/AltitudeScale.js
+++ b/src/preview/AltitudeScale.js
@@ -26,7 +26,12 @@ export default class AltitudeScale extends PreviewBase {
       const hAlignment = scaleAlignment === 0 ? 0 : 2;
       const prefix = this.props.scaleType === 0 ? 'AAlt' : 'Alt';
       const prefixPosition = Canvas.calculateStringPosition(prefix, 0, 0, hAlignment, 0, font);
-      const unitString = 'M';
+      var unitString = ''
+      if (this.props.units === 0) {
+        unitString = 'KM';
+      } else {
+        unitString = 'F';
+      }
       const unitPosition = Canvas.calculateStringPosition(
         unitString, 0, 0, hAlignment, 0, font);
       const altitude = this.props.scaleType === 0 ? absoluteAltitude : relativeAltitude;

--- a/src/preview/SpeedScale.js
+++ b/src/preview/SpeedScale.js
@@ -26,7 +26,12 @@ export default class SpeedScale extends PreviewBase {
       const hAlignment = scaleAlignment === 0 ? 0 : 2;
       const prefix = this.props.scaleType === 0 ? 'GS' : 'AS';
       const prefixPosition = Canvas.calculateStringPosition(prefix, 0, 0, hAlignment, 0, font);
-      const unitString = 'KM/H';
+      var unitString = ''
+      if (this.props.units === 0) {
+        unitString = 'KM/H';
+      } else {
+        unitString = 'M/H';
+      }
       const unitPosition = Canvas.calculateStringPosition(
         unitString, 0, 0, hAlignment, 0, font);
       const speed = this.props.scaleType === 0 ? speedGround : speedAir;


### PR DESCRIPTION
 Preview only showed metric, even if you'd selected imperial, for both of the scale controls - AltitudeScale and SpeedScale.

